### PR TITLE
fix: sync rendered clocks to Nepal time

### DIFF
--- a/frontend/src/api/websocket.ts
+++ b/frontend/src/api/websocket.ts
@@ -23,6 +23,11 @@ export interface WebSocketMessage {
 export type MessageHandler = (message: WebSocketMessage) => void
 export type ConnectionHandler = (connected: boolean) => void
 
+export interface ServerClockSnapshot {
+  serverEpochMs: number | null
+  receivedAtPerfMs: number | null
+}
+
 interface SubscribeMessage {
   type: 'subscribe' | 'unsubscribe'
   channel: string
@@ -227,6 +232,7 @@ export class OSINTWebSocket {
       let message: WebSocketMessage
 
       if (rawMessage.type === 'heartbeat' || rawMessage.type === 'pong') {
+        _syncServerClock(rawMessage.timestamp)
         // Extract viewer count from heartbeat if present
         if (typeof rawMessage.viewers === 'number') {
           _setViewerCount(rawMessage.viewers)
@@ -235,6 +241,7 @@ export class OSINTWebSocket {
       }
 
       if (rawMessage.type === 'viewer_count') {
+        _syncServerClock(rawMessage.timestamp)
         if (typeof rawMessage.viewers === 'number') {
           _setViewerCount(rawMessage.viewers)
         }
@@ -283,6 +290,8 @@ export class OSINTWebSocket {
           timestamp: rawMessage.timestamp || new Date().toISOString(),
         }
       }
+
+      _syncServerClock(message.timestamp)
 
       // Get handlers for this channel
       const channel = message.channel as WebSocketChannel
@@ -358,11 +367,29 @@ export class OSINTWebSocket {
 // ── Live viewer count (external store for useSyncExternalStore) ──
 let _viewerCount = 0
 const _viewerListeners = new Set<() => void>()
+let _serverClock: ServerClockSnapshot = {
+  serverEpochMs: null,
+  receivedAtPerfMs: null,
+}
+const _serverClockListeners = new Set<() => void>()
 
 export function _setViewerCount(count: number) {
   if (count === _viewerCount) return
   _viewerCount = count
   _viewerListeners.forEach(l => l())
+}
+
+function _syncServerClock(timestamp: unknown) {
+  if (typeof timestamp !== 'string') return
+
+  const serverEpochMs = Date.parse(timestamp)
+  if (Number.isNaN(serverEpochMs)) return
+
+  _serverClock = {
+    serverEpochMs,
+    receivedAtPerfMs: performance.now(),
+  }
+  _serverClockListeners.forEach((listener) => listener())
 }
 
 export function subscribeViewerCount(cb: () => void) {
@@ -372,6 +399,19 @@ export function subscribeViewerCount(cb: () => void) {
 
 export function getViewerCountSnapshot() { return _viewerCount }
 export function getViewerCountServerSnapshot() { return 0 }
+
+export function subscribeServerClock(cb: () => void) {
+  _serverClockListeners.add(cb)
+  return () => { _serverClockListeners.delete(cb) }
+}
+
+export function getServerClockSnapshot() { return _serverClock }
+export function getServerClockServerSnapshot(): ServerClockSnapshot {
+  return {
+    serverEpochMs: null,
+    receivedAtPerfMs: null,
+  }
+}
 
 // Singleton instance
 let wsInstance: OSINTWebSocket | null = null

--- a/frontend/src/components/Dashboard/DashboardHeader.tsx
+++ b/frontend/src/components/Dashboard/DashboardHeader.tsx
@@ -9,6 +9,8 @@ import { useUserPreferencesStore } from '../../store/slices/userPreferencesSlice
 import { useNotificationStore } from '../../stores/notificationStore';
 import apiClient from '../../api/client';
 import { subscribeViewerCount, getViewerCountSnapshot, getViewerCountServerSnapshot } from '../../api/websocket';
+import { useNepalClock } from '../../hooks/useNepalClock';
+import { formatNepalShortDate, formatNepalTime, NEPAL_TIME_LABEL } from '../../utils/nepalTime';
 import { NotificationBell } from '../common/NotificationBell';
 
 const PRESET_TABS = [
@@ -27,20 +29,17 @@ const ViewerBadge = memo(function ViewerBadge() {
 });
 
 const Clock = memo(function Clock() {
-  const [time, setTime] = useState(new Date());
-
-  useEffect(() => {
-    const timer = setInterval(() => setTime(new Date()), 1000);
-    return () => clearInterval(timer);
-  }, []);
-
-  const hh = time.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
-  const date = time.toLocaleDateString('en-GB', { day: '2-digit', month: 'short' }).toUpperCase();
+  const { now, isServerSynced } = useNepalClock();
 
   return (
-    <div className="hidden sm:flex items-center gap-2" style={{ fontFamily: 'var(--font-mono)', fontSize: 11, fontVariantNumeric: 'tabular-nums' }}>
-      <span style={{ color: 'var(--text-muted)' }}>{date}</span>
-      <span style={{ color: 'var(--text-secondary)', fontWeight: 600 }}>{hh}</span>
+    <div
+      className="hidden sm:flex items-center gap-2"
+      style={{ fontFamily: 'var(--font-mono)', fontSize: 11, fontVariantNumeric: 'tabular-nums' }}
+      title={isServerSynced ? 'Server-synced Nepal time' : 'Awaiting server time sync; temporarily using local clock'}
+    >
+      <span style={{ color: 'var(--text-muted)' }}>{formatNepalShortDate(now)}</span>
+      <span style={{ color: 'var(--text-secondary)', fontWeight: 600 }}>{formatNepalTime(now)}</span>
+      <span style={{ color: 'var(--text-disabled)', letterSpacing: '0.08em' }}>{NEPAL_TIME_LABEL}</span>
     </div>
   );
 });

--- a/frontend/src/components/Dashboard/StatusBar.tsx
+++ b/frontend/src/components/Dashboard/StatusBar.tsx
@@ -3,8 +3,10 @@ import { Wifi, WifiOff, Database, Activity, Zap, AlertTriangle, TrendingDown, Tr
 import { useAuthStore } from '../../store/slices/authSlice';
 import { useSettingsStore } from '../../store/slices/settingsSlice';
 import { usePermissions } from '../../hooks/usePermissions';
+import { useNepalClock } from '../../hooks/useNepalClock';
 import apiClient from '../../api/client';
 import { subscribeViewerCount, getViewerCountSnapshot, getViewerCountServerSnapshot } from '../../api/websocket';
+import { formatNepalLongDate, formatNepalTime, NEPAL_TIME_LABEL } from '../../utils/nepalTime';
 
 interface KPISnapshot {
   active_alerts: {
@@ -51,37 +53,18 @@ const ViewerCount = memo(function ViewerCount() {
 
 // Extracted clock component — only this re-renders every second
 const StatusClock = memo(function StatusClock() {
-  const [time, setTime] = useState(new Date());
-
-  useEffect(() => {
-    const timer = setInterval(() => setTime(new Date()), 1000);
-    return () => clearInterval(timer);
-  }, []);
-
-  const formatTime = (date: Date) => {
-    return date.toLocaleTimeString('en-GB', {
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-      hour12: false,
-    });
-  };
-
-  const formatDate = (date: Date) => {
-    return date.toLocaleDateString('en-GB', {
-      day: '2-digit',
-      month: 'short',
-      year: 'numeric',
-    }).toUpperCase();
-  };
+  const { now, isServerSynced } = useNepalClock();
 
   return (
-    <div className="status-section">
-      <span className="status-value">{formatDate(time)}</span>
+    <div
+      className="status-section"
+      title={isServerSynced ? 'Server-synced Nepal time' : 'Awaiting server time sync; temporarily using local clock'}
+    >
+      <span className="status-value">{formatNepalLongDate(now)}</span>
       <span className="status-value" style={{ color: 'var(--bloomberg-orange)', fontWeight: 600 }}>
-        {formatTime(time)}
+        {formatNepalTime(now)}
       </span>
-      <span className="status-label">{time.toLocaleTimeString('en-US', { timeZoneName: 'short' }).split(' ').pop()}</span>
+      <span className="status-label">{NEPAL_TIME_LABEL}</span>
     </div>
   );
 });

--- a/frontend/src/hooks/useNepalClock.ts
+++ b/frontend/src/hooks/useNepalClock.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState, useSyncExternalStore } from 'react'
+import {
+  connectWebSocket,
+  getServerClockServerSnapshot,
+  getServerClockSnapshot,
+  subscribeServerClock,
+} from '../api/websocket'
+
+export function useNepalClock() {
+  const serverClock = useSyncExternalStore(
+    subscribeServerClock,
+    getServerClockSnapshot,
+    getServerClockServerSnapshot,
+  )
+  const [, setTick] = useState(0)
+
+  useEffect(() => {
+    connectWebSocket()
+  }, [])
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setTick((value) => value + 1)
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [])
+
+  const hasServerSync =
+    serverClock.serverEpochMs !== null && serverClock.receivedAtPerfMs !== null
+
+  let nowMs = Date.now()
+  if (hasServerSync) {
+    const serverEpochMs = serverClock.serverEpochMs!
+    const receivedAtPerfMs = serverClock.receivedAtPerfMs!
+    nowMs =
+      serverEpochMs +
+      Math.max(0, performance.now() - receivedAtPerfMs)
+  }
+
+  return {
+    now: new Date(nowMs),
+    isServerSynced: hasServerSync,
+  }
+}

--- a/frontend/src/pages/AnalystWorkspace.tsx
+++ b/frontend/src/pages/AnalystWorkspace.tsx
@@ -7,11 +7,14 @@ import { QueuePanel } from '../components/workspace/QueuePanel'
 import { MainCanvas } from '../components/workspace/MainCanvas'
 import { ContextPanel } from '../components/workspace/ContextPanel'
 import { CommandBar } from '../components/workspace/CommandBar'
+import { useNepalClock } from '../hooks/useNepalClock'
 import { useWorkspaceStore } from '../stores/workspaceStore'
+import { formatNepalTime, NEPAL_TIME_LABEL } from '../utils/nepalTime'
 import '../styles/professional-dashboard.css'
 
 function StatusBar() {
   const { bulkMode, selectedItems, toggleShortcutsHelp } = useWorkspaceStore()
+  const { now } = useNepalClock()
 
   return (
     <div className="h-full flex items-center px-4 gap-4 text-[10px] font-mono text-bp-text-muted">
@@ -34,7 +37,7 @@ function StatusBar() {
       {/* Time */}
       <div className="flex items-center gap-2">
         <Clock size={12} />
-        <span>{new Date().toLocaleTimeString('en-US', { hour12: false })} NPT</span>
+        <span>{formatNepalTime(now)} {NEPAL_TIME_LABEL}</span>
       </div>
 
       {/* Bulk selection indicator */}

--- a/frontend/src/pages/CorporateIntel.tsx
+++ b/frontend/src/pages/CorporateIntel.tsx
@@ -37,8 +37,10 @@ import { AnalyticsDashboard } from '../components/corporate/AnalyticsDashboard'
 import { AnomalyDashboard } from '../components/corporate/AnomalyDashboard'
 import { CaseManager } from '../components/corporate/CaseManager'
 import { CompanyProfilePanel } from '../components/corporate/CompanyProfilePanel'
+import { useNepalClock } from '../hooks/useNepalClock'
 import { AnalystShell } from '../components/layout/AnalystShell'
 import { DataValueGrid } from '../components/ui/narada-ui'
+import { formatNepalTime, NEPAL_TIME_LABEL } from '../utils/nepalTime'
 import {
   getCorporateStats,
   searchCompanies,
@@ -395,6 +397,7 @@ function PhoneLinksSection({
 // ── Main Workstation ────────────────────────────────────────
 
 export default function CorporateIntel() {
+  const { now } = useNepalClock()
   const [activeTab, setActiveTab] = useState<TabId>('overview')
 
   // Drawer state
@@ -611,7 +614,7 @@ export default function CorporateIntel() {
             </div>
             <div className="flex items-center gap-4">
               <span>Shortcuts: press ? for help</span>
-              <span>{new Date().toLocaleTimeString('en-US', { hour12: false })} NPT</span>
+              <span>{formatNepalTime(now)} {NEPAL_TIME_LABEL}</span>
             </div>
           </div>
         )}

--- a/frontend/src/pages/DamageAssessment.tsx
+++ b/frontend/src/pages/DamageAssessment.tsx
@@ -42,6 +42,8 @@ import { OverviewTab } from '../components/damage-assessment/tabs/OverviewTab';
 import { SpatialTab } from '../components/damage-assessment/tabs/SpatialTab';
 import { PwttEvidenceTab } from '../components/damage-assessment/tabs/PwttEvidenceTab';
 import { QuickHotspotChecker } from '../components/damage-assessment/QuickHotspotChecker';
+import { useNepalClock } from '../hooks/useNepalClock';
+import { formatNepalTime, NEPAL_TIME_LABEL } from '../utils/nepalTime';
 
 const TABS = [
   { id: 'overview', label: 'Overview', icon: LayoutDashboard, description: 'Key metrics and findings' },
@@ -344,6 +346,7 @@ function statusIntent(status: string): Intent {
 }
 
 export default function DamageAssessment() {
+  const { now } = useNepalClock();
   const queryClient = useQueryClient();
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>('overview');
@@ -604,7 +607,7 @@ export default function DamageAssessment() {
               {selectedRunId && <span>Run: {selectedRunId.slice(0, 8)}</span>}
             </div>
             <div className="flex items-center gap-4">
-              <span>{new Date().toLocaleTimeString('en-US', { hour12: false })} NPT</span>
+              <span>{formatNepalTime(now)} {NEPAL_TIME_LABEL}</span>
             </div>
           </div>
         )}

--- a/frontend/src/pages/TradeAnalysis.tsx
+++ b/frontend/src/pages/TradeAnalysis.tsx
@@ -38,6 +38,8 @@ import {
   type TradeWorkbenchSummary,
   type TradeWorkbenchTopItem,
 } from '../api/connectedAnalyst';
+import { useNepalClock } from '../hooks/useNepalClock';
+import { formatNepalTime, NEPAL_TIME_LABEL } from '../utils/nepalTime';
 
 interface HsChartRow {
   hsCode: string;
@@ -107,6 +109,7 @@ function exportRowsToCsv(rows: TradeWorkbenchDrillRow[]): void {
 }
 
 export default function TradeAnalysis() {
+  const { now } = useNepalClock();
   const [fiscalYear, setFiscalYear] = useState('');
   const [direction, setDirection] = useState('');
   const [hsCode, setHsCode] = useState('');
@@ -437,7 +440,7 @@ export default function TradeAnalysis() {
           <div className="flex items-center gap-4">
             <span>{rows.length} drill rows</span>
             <span>{anomalies.length} anomalies</span>
-            <span>{new Date().toLocaleTimeString('en-US', { hour12: false })} NPT</span>
+            <span>{formatNepalTime(now)} {NEPAL_TIME_LABEL}</span>
           </div>
         </div>
       )}

--- a/frontend/src/utils/nepalTime.ts
+++ b/frontend/src/utils/nepalTime.ts
@@ -1,0 +1,35 @@
+export const NEPAL_TIME_ZONE = 'Asia/Kathmandu'
+export const NEPAL_TIME_LABEL = 'NPT'
+
+const nepalTimeFormatter = new Intl.DateTimeFormat('en-GB', {
+  timeZone: NEPAL_TIME_ZONE,
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+})
+
+const nepalShortDateFormatter = new Intl.DateTimeFormat('en-GB', {
+  timeZone: NEPAL_TIME_ZONE,
+  day: '2-digit',
+  month: 'short',
+})
+
+const nepalLongDateFormatter = new Intl.DateTimeFormat('en-GB', {
+  timeZone: NEPAL_TIME_ZONE,
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+})
+
+export function formatNepalTime(date: Date): string {
+  return nepalTimeFormatter.format(date)
+}
+
+export function formatNepalShortDate(date: Date): string {
+  return nepalShortDateFormatter.format(date).toUpperCase()
+}
+
+export function formatNepalLongDate(date: Date): string {
+  return nepalLongDateFormatter.format(date).toUpperCase()
+}


### PR DESCRIPTION
## Summary
- move the rendered dashboard clock to Nepal time on the components users actually see
- replace ambiguous `NST`-style labeling with `NPT`
- source the clock from backend websocket timestamps when available instead of relying only on the client machine clock

## What Changed
- added a shared Nepal time formatter and `useNepalClock` hook
- taught `frontend/src/api/websocket.ts` to track the latest backend timestamp from heartbeat/message traffic
- updated the actual dashboard header clock in `frontend/src/components/Dashboard/DashboardHeader.tsx`
- updated `frontend/src/components/Dashboard/StatusBar.tsx` for parity
- updated other visible analyst status bars that were still rendering `new Date()` with a hardcoded `NPT` suffix:
  - `frontend/src/pages/AnalystWorkspace.tsx`
  - `frontend/src/pages/TradeAnalysis.tsx`
  - `frontend/src/pages/CorporateIntel.tsx`
  - `frontend/src/pages/DamageAssessment.tsx`

## Why This Addresses The Review Comments
- the rendered dashboard clock is in `DashboardHeader`, not only `Dashboard/StatusBar`, so this PR fixes the live UI path
- the timezone label is now `NPT`
- once websocket heartbeat data is available, the clock advances from a server timestamp plus monotonic elapsed time, which is materially better than formatting the user's local system clock in a different timezone

## Validation
- targeted eslint run on changed files completed without errors from these changes; only existing Blueprint warnings remain in `TradeAnalysis.tsx` and `DamageAssessment.tsx`
- full `npm run build` is still blocked by pre-existing TypeScript errors in:
  - `src/api/hooks/useTwitter.ts`
  - `src/components/Dashboard/widgets/index.tsx`
